### PR TITLE
Switch from Kernel.open to URI.open

### DIFF
--- a/lib/refile/s3.rb
+++ b/lib/refile/s3.rb
@@ -95,10 +95,10 @@ module Refile
     # @param [String] id           The id of the file
     # @return [IO]                An IO object containing the file contents
     verify_id def open(id)
-      Kernel.open(object(id).presigned_url(:get))
+      URI.open(object(id).presigned_url(:get))
     rescue Net::OpenTimeout
       sleep 0.5
-      Kernel.open(object(id).presigned_url(:get))
+      URI.open(object(id).presigned_url(:get))
     end
 
     # Return the entire contents of the uploaded file as a String.

--- a/spec/refile/s3_spec.rb
+++ b/spec/refile/s3_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Refile::S3 do
     end
 
     it "retries open when Net::OpenTimeout raised" do
-      expect(Kernel).to receive(:open).once
+      expect(URI).to receive(:open).once
       expect(s3_object).to receive(:presigned_url).ordered.and_raise(Net::OpenTimeout)
       expect(s3_object).to receive(:presigned_url).ordered
 


### PR DESCRIPTION
## What

Switch form Kernel.open to URI.open

## Why

Ruby 3 removed the previously deprecated functionality of using Kernel.open to open URIs which was causing errors.